### PR TITLE
fix(builtin_checkers): fix float compare without using relative error

### DIFF
--- a/native/builtin_checkers/floats.h
+++ b/native/builtin_checkers/floats.h
@@ -8,8 +8,8 @@ void builtinCheckerFloats(int precision) {
         n++;
         double j = ans.readDouble();
         double p = ouf.readDouble();
-        if (fabs(j - p) > eps + 1E-15)
-            quitf(_wa, "%d%s number differ - expected: '%.10f', found: '%.10f'", n, englishEnding(n).c_str(), j, p);
+        if (!doubleCompare(j, p, eps))
+            quitf(_wa, "%d%s number differ - expected: '%.10f', found: '%.10f', error = '%.10f'", n, englishEnding(n).c_str(), j, p, doubleDelta(j, p));
     }
 
     int extraInAnsCount = 0;


### PR DESCRIPTION
When using float compare, it's expected that return OK when the absolute error or relative error is no more than EPS, but in the code, the relative error is ignored. This commit fixes it.